### PR TITLE
iss19

### DIFF
--- a/nl2flow/plan/planners.py
+++ b/nl2flow/plan/planners.py
@@ -79,10 +79,8 @@ class Kstar(Planner):
         confirm_options: Set[ConfirmOptions] = flow.confirm_options
 
         for plan in raw_plans:
+            new_plan = ClassicalPlan(cost=plan.cost, reference=plan.actions)
             actions = plan.actions
-            length = len(actions)
-
-            new_plan = ClassicalPlan(cost=plan.cost, length=length)
 
             for action in actions:
                 action_split = action.split()
@@ -105,7 +103,7 @@ class Kstar(Planner):
             if ConfirmOptions.group_confirms in confirm_options:
                 new_plan = group_items(new_plan, ConfirmOptions.group_confirms)
 
-            if new_plan.length:
-                planner_response.list_of_plans.append(new_plan)
+            new_plan.length = len(new_plan.plan)
+            planner_response.list_of_plans.append(new_plan)
 
         return planner_response

--- a/nl2flow/plan/schemas.py
+++ b/nl2flow/plan/schemas.py
@@ -42,6 +42,7 @@ class ClassicalPlan(BaseModel):
     cost: float = 0.0
     length: float = 0.0
     metadata: Optional[Any] = None
+    reference: List[str]
     plan: List[Action] = []
 
 

--- a/nl2flow/plan/utils.py
+++ b/nl2flow/plan/utils.py
@@ -37,6 +37,7 @@ def group_items(plan: ClassicalPlan, option: Union[SlotOptions, MappingOptions, 
         cost=plan.cost,
         length=plan.length,
         metadata=plan.metadata,
+        reference=plan.reference,
     )
 
     new_start_of_plan = 0


### PR DESCRIPTION
+ [x] #19 Fix to length of prettified plan
+ [x] Added a [new key in the plan object](https://github.com/IBM/nl2flow/blob/iss19/nl2flow/plan/schemas.py#L45) to contain the reference plan that came out of the planner, in case we need it later for making sense of things.