### PR TITLE
Fix a typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
 #
 # For an analysis of this field vs pip's requirements files see:
 # https://packaging.python.org/discussions/install-requires-vs-requirements/
-dependencies = ["pydantic>=2.4.2", "pyyaml", "tarski", "StrEnum", "kstar-planner", "forbiditerative", "haikunator", "Pebble"]
+dependencies = ["pydantic>=2.4.2", "pyyaml", "tarski", "StrEnum", "kstar-planner", "forbiditerative", "haikunator", "pebble"]
 
 [project.optional-dependencies]
 dev = ["check-manifest", "pytest", "pytest-mock", "black", "pylint", "flake8", "pre-commit", "Flake8-pyproject", "coverage", "pytest-mock", "types-PyYAML"]


### PR DESCRIPTION
`Pebble` should be  `pebble`