### PR TITLE
Change Enum to str, enum for llm plan validation

### DIFF
--- a/nl2flow/debug/schemas.py
+++ b/nl2flow/debug/schemas.py
@@ -5,12 +5,12 @@ from pydantic import BaseModel
 from enum import Enum
 
 
-class DiffAction(Enum):
+class DiffAction(str, Enum):
     ADD = "+"
     DELETE = "-"
 
 
-class SolutionQuality(Enum):
+class SolutionQuality(str, Enum):
     SOUND = "SOUND"
     VALID = "VALID"
     OPTIMAL = "OPTIMAL"


### PR DESCRIPTION
I confirm that this change allows MongoDB to accept plan validation data.

https://github.com/IBM/nl2flow/issues/78