### PR TITLE
iss93

### DIFF
--- a/profiler/generators/dataset_generator/dataset_generator.py
+++ b/profiler/generators/dataset_generator/dataset_generator.py
@@ -41,7 +41,7 @@ def generate_dataset_with_info_generator(
                 pddl_domain=trim_pddl_str(pddl.domain, pddl_start_key),
                 pddl_problem=trim_pddl_str(pddl.problem, pddl_start_key),
                 list_of_plans=planner_response.list_of_plans,
-                prettified_plans=CodeLikePrint.pretty_print(planner_response) if should_plan else "",
+                prettified_plans=CodeLikePrint.pretty_print(planner_response, show_output=False) if should_plan else "",
                 prettified_optimal_plan_forward=(
                     VerbalizePrint.pretty_print_plan(planner_response.list_of_plans[0], flow_object=flow)
                     if len(planner_response.list_of_plans) > 0

--- a/profiler/generators/description_generator/descripter_generator_data.py
+++ b/profiler/generators/description_generator/descripter_generator_data.py
@@ -1,10 +1,14 @@
+from nl2flow.compile.options import BasicOperations
+
 ask_description = (
-    "The system has action ask."
-    + " Action ask lets the system ask the user about the value of "
+    f"The system has action {BasicOperations.SLOT_FILLER.value}."
+    + f" Action {BasicOperations.SLOT_FILLER.value} lets the system ask the user about the value of "
     + "any variable unless that variable is explicitly marked as cannot be "
-    + "acquired from the user. Action ask is less preferred "
+    + f"acquired from the user. Action {BasicOperations.SLOT_FILLER.value} is less preferred "
     + "than acquiring the value of a variable through other actions."
 )
-map_description = "Action map is used when a value for one variable can be used for another variable."
+map_description = (
+    f"Action {BasicOperations.MAPPER.value} is used when a value for one variable can be used for another variable."
+)
 action_requirement = "To execute an action the values of their inputs must be known."
 system_goal_description = "The goal of the system is to execute one or more actions."

--- a/profiler/generators/description_generator/description_generator_helper.py
+++ b/profiler/generators/description_generator/description_generator_helper.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple, Union
+from nl2flow.compile.options import BasicOperations
 from profiler.data_types.agent_info_data_types import (
     SIGNATURE_TYPES,
     AgentInfo,
@@ -228,7 +229,7 @@ def get_agent_info_description(agent_info: AgentInfo) -> Tuple[str, str]:
 
 
 def get_mapping_description(mapping: Tuple[str, str, float]) -> str:
-    return f"Action map can determine the value of variable {mapping[0]} from variable {mapping[1]}."
+    return f"Action {BasicOperations.MAPPER.value} can determine the value of variable {mapping[0]} from variable {mapping[1]}."
 
 
 def get_mappings_description(mappings: List[Tuple[str, str, float]]) -> str:

--- a/profiler/generators/description_generator/description_generator_helper.py
+++ b/profiler/generators/description_generator/description_generator_helper.py
@@ -147,15 +147,27 @@ def get_names_from_signature_items(
 
 def get_action_variable_description(agent_info: AgentInfo) -> str:
     sig = agent_info.actuator_signature
-    variable_names = get_names_from_signature_items_no_category(
-        sig.in_sig_full
-    ) + get_names_from_signature_items_no_category(sig.out_sig_full)
+    input_variable_names = get_names_from_signature_items_no_category(sig.in_sig_full)
+    output_variable_names = get_names_from_signature_items_no_category(sig.out_sig_full)
 
-    if len(variable_names) > 0:
-        part_list: List[str] = [f"Action {agent_info.agent_id} has"]
-        part_list.append("variable" if len(variable_names) == 1 else "variables")
-        part_list.append(get_names(list(set(variable_names))))
+    part_list: List[str] = [f"Action {agent_info.agent_id}"]
+
+    if len(input_variable_names) > 0:
+        part_list.append("has input parameter" if len(input_variable_names) == 1 else "has input parameters")
+        part_list.append(get_names(list(set(input_variable_names))))
+
+        if len(output_variable_names) == 0:
+            return " ".join(part_list) + "."
+
+    if len(output_variable_names) > 0:
+        if len(input_variable_names) > 0:
+            part_list.append("and it")
+
+        part_list.append("outputs variable" if len(output_variable_names) == 1 else "outputs variables")
+        part_list.append(get_names(list(set(output_variable_names))))
+
         return " ".join(part_list) + "."
+
     return ""
 
 
@@ -164,7 +176,11 @@ def get_action_condition_description(agent_info: AgentInfo, is_in_sig: bool) -> 
     variable_names = get_names_from_signature_items_no_category(sig.in_sig_full if is_in_sig else sig.out_sig_full)
 
     if len(variable_names) == 0:
-        return f"Action {agent_info.agent_id} can be executed without knowing any variable" if is_in_sig else ""
+        return (
+            f"Action {agent_info.agent_id} can be executed without knowing the value of any variable"
+            if is_in_sig
+            else ""
+        )
 
     variable_names = list(set(variable_names))
     part_list: List[str] = []
@@ -174,7 +190,7 @@ def get_action_condition_description(agent_info: AgentInfo, is_in_sig: bool) -> 
         part_list.append(f"To execute action {agent_info.agent_id},")
         part_list.append(prepend_word)
         part_list.append(get_names(variable_names))
-        part_list.append("should be known.")
+        part_list.append("must be known.")
     else:
         part_list.append(f"After executing action {agent_info.agent_id},")
         part_list.append(prepend_word)

--- a/tests/profiler/generators/description_generator/test_description_generator.py
+++ b/tests/profiler/generators/description_generator/test_description_generator.py
@@ -37,6 +37,7 @@ class TestDescriptionGenerator:
         samples, _ = generate_agent_infos(agent_info_generator_input, random)
 
         assert samples[0].describe() is not None
+        print(samples[0].describe())
 
     def test_get_sample_description_json(self) -> None:
         agent_info_generator_input: AgentInfoGeneratorInput = AgentInfoGeneratorInput(


### PR DESCRIPTION
+ [x] Reuse same names for basic operations so if we change it in one place it reflects in all the descriptions.
+ [x] #93 changes to the action description
  + Changed should to must
  + Explicitly said input parameters and outputs in hope that the parameter mixup in the llm outputs improve
  + Killed variable output 

The action description part now reads:

```
Action a__0 has input parameters v__0 and v__1 and it outputs variables v__2 and v__4. To execute action a__0, variables v__0 and v__1 must be known. After executing action a__0, variables v__2 and v__4 are known.
```