### PR TITLE
Option for flow validation

### DIFF
--- a/nl2flow/compile/flow.py
+++ b/nl2flow/compile/flow.py
@@ -17,11 +17,8 @@ from nl2flow.compile.options import (
 
 
 class Flow:
-    def __init__(
-        self,
-        name: str,
-    ):
-        self._flow_definition = FlowDefinition(name=name)
+    def __init__(self, name: str, validate: bool = True):
+        self._flow_definition = FlowDefinition(name=name, validate_assignment=validate)
         self._mapping_option: Set[MappingOptions] = {MappingOptions.relaxed}
         self._confirm_option: Set[ConfirmOptions] = set()
         self._variable_life_cycle: Set[LifeCycleOptions] = set()

--- a/nl2flow/compile/schemas.py
+++ b/nl2flow/compile/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Set, List, Dict, Optional, Union, Any
 from collections import Counter
 from re import findall
-from pydantic import BaseModel, field_validator, model_validator, ConfigDict
+from pydantic import BaseModel, field_validator, model_validator
 from pydantic_core.core_schema import FieldValidationInfo
 from nl2flow.compile.utils import string_transform, revert_string_transform, Transform
 from nl2flow.compile.options import (
@@ -246,8 +246,6 @@ class ClassicalPlanReference(BaseModel):
 
 
 class FlowDefinition(BaseModel):
-    model_config = ConfigDict(validate_assignment=True)
-
     name: str
     type_hierarchy: List[TypeItem] = []
     operators: List[OperatorDefinition] = []
@@ -262,6 +260,12 @@ class FlowDefinition(BaseModel):
     starts_with: Optional[str] = None
     ends_with: Optional[str] = None
     reference: Optional[ClassicalPlanReference] = None
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        self.model_config["validate_assignment"] = data.get(
+            "validate_assignment", self.model_config.get("validate_assignment", True)
+        )
 
     @classmethod
     def transform(cls, flow: FlowDefinition, transforms: List[Transform]) -> FlowDefinition:

--- a/tests/errors/test_duplicates.py
+++ b/tests/errors/test_duplicates.py
@@ -1,6 +1,7 @@
 from tests.testing import BaseTestAgents
 from nl2flow.compile.operators import ClassicalOperator as Operator
 from nl2flow.compile.options import GoalType
+from nl2flow.compile.flow import Flow
 from nl2flow.compile.schemas import (
     TypeItem,
     MemoryItem,
@@ -23,6 +24,22 @@ class TestDuplicates(BaseTestAgents):
 
         with pytest.raises(Exception):
             self.flow.add([agent_1, agent_2])
+
+    def test_relaxed_assignment(self) -> None:
+        agent_1 = Operator("Agent")
+        agent_2 = Operator("Agent")
+
+        flow_definition = self.flow.flow_definition
+
+        new_flow = Flow(name="Test Validated Assignment")
+        new_flow.flow_definition = flow_definition
+
+        with pytest.raises(Exception):
+            self.flow.add([agent_1, agent_2])
+
+        new_flow = Flow(name="Test Relaxed Assignment", validate=False)
+        new_flow.flow_definition = flow_definition
+        new_flow.add([agent_1, agent_2])
 
     def test_duplicate_types(self) -> None:
         with pytest.raises(Exception):


### PR DESCRIPTION
+ #115 

This makes it easier for external usage with dirty data. When validation is turned off, will still get solutions but sometimes with unpredictable circumstances e.g. when there are operators or fields with conflicting names.