### PR TITLE
ISS152

### DIFF
--- a/nl2flow/debug/debug.py
+++ b/nl2flow/debug/debug.py
@@ -109,9 +109,10 @@ class BasicDebugger(Debugger):
                 reference = ClassicalPlan.from_reference(plan)
 
                 new_kwargs = deepcopy(kwargs)
-                del new_kwargs["show_output"]
+                new_kwargs["show_output"] = False
+                new_kwargs["line_numbers"] = False
 
-                list_of_tokens = printer.pretty_print_plan(reference, show_output=False, **new_kwargs).split("\n")
+                list_of_tokens = printer.pretty_print_plan(reference, **new_kwargs).split("\n")
 
             new_report.plan_diff_str = self.generate_plan_diff(printer, best_plan, list_of_tokens, **kwargs)
             new_report.plan_diff_obj = self.generate_plan_diff_obj(printer, new_report.plan_diff_str, **kwargs)

--- a/nl2flow/debug/debug.py
+++ b/nl2flow/debug/debug.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import List, Any
+from typing import List, Any, Optional
 from difflib import Differ
+from copy import deepcopy
 from nl2flow.plan.planners.kstar import Kstar
 from nl2flow.plan.options import TIMEOUT
 from nl2flow.plan.schemas import ClassicalPlan
@@ -100,6 +101,17 @@ class BasicDebugger(Debugger):
 
         if len(planner_response.list_of_plans) > 0:
             best_plan = planner_response.best_plan
+
+            show_output: Optional[bool] = kwargs.get("show_output", None)
+
+            if "show_output" in kwargs and show_output is None:
+                plan = printer.parse_tokens(list_of_tokens, **kwargs)
+                reference = ClassicalPlan.from_reference(plan)
+
+                new_kwargs = deepcopy(kwargs)
+                del new_kwargs["show_output"]
+
+                list_of_tokens = printer.pretty_print_plan(reference, show_output=False, **new_kwargs).split("\n")
 
             new_report.plan_diff_str = self.generate_plan_diff(printer, best_plan, list_of_tokens, **kwargs)
             new_report.plan_diff_obj = self.generate_plan_diff_obj(printer, new_report.plan_diff_str, **kwargs)

--- a/nl2flow/printers/codelike.py
+++ b/nl2flow/printers/codelike.py
@@ -12,7 +12,7 @@ class CodeLikePrint(Printer):
     @classmethod
     def pretty_print_plan(cls, plan: Plan, **kwargs: Any) -> str:
         show_output: bool = kwargs.get("show_output", True)
-        line_numbers: bool = kwargs.get("line_numbers", True)
+        line_numbers: bool = kwargs.get("line_numbers", False)
         collapse_maps: bool = kwargs.get("collapse_maps", False)
         start_at: int = kwargs.get("start_at", 0)
 

--- a/nl2flow/printers/codelike.py
+++ b/nl2flow/printers/codelike.py
@@ -12,7 +12,7 @@ class CodeLikePrint(Printer):
     @classmethod
     def pretty_print_plan(cls, plan: Plan, **kwargs: Any) -> str:
         show_output: bool = kwargs.get("show_output", True)
-        line_numbers: bool = kwargs.get("line_numbers", False)
+        line_numbers: bool = kwargs.get("line_numbers", True)
         collapse_maps: bool = kwargs.get("collapse_maps", False)
         start_at: int = kwargs.get("start_at", 0)
 

--- a/tests/debugger/test_debugger_from_flow.py
+++ b/tests/debugger/test_debugger_from_flow.py
@@ -69,10 +69,7 @@ class TestBasic:
         stringify_tokens = "\n".join([f"[{index}] {token}" for index, token in enumerate(self.tokens)])
         planner_response = self.flow.plan_it(PLANNER)
         assert any(
-            [
-                stringify_tokens == CodeLikePrint.pretty_print_plan(plan, line_numbers=True)
-                for plan in planner_response.list_of_plans
-            ]
+            [stringify_tokens == CodeLikePrint.pretty_print_plan(plan) for plan in planner_response.list_of_plans]
         )
 
     def test_token_parsing(self) -> None:


### PR DESCRIPTION
I was testing out what happens where with a simple test case [here](https://github.com/IBM/nl2flow/blob/disorder/tests/debugger/test_debugger_from_flow.py#L231) with disordered parameters. It seems to me that this is an impossible issue to fix because without named references even parsing a set of tokens reliably is impossible: 

1. If the names are not in order we don't know which one is which 
2. If we assume that they are named the same, then we cannot do a parse if some of them are missing (or there are more than what there should be) -- both are common cases for llm output.
3. Re: 2, We cant even assume they are named the same coz of maps made along the way. 

In the end, in programming terms, we cannot do function calls with unassigned parameters as well as no order at the same time for the same reasons. 

I suggest we either do actual named assignments, like we do in refraction [[example](https://github.ibm.com/research-dba/refraction/blob/main/tests/nestful_experiments/test_mistakes.py#L20)], or we put it in the instructions to the LLM that parameters should be in order and if it can't do it we should count it as a wrong plan instead of trying to hack a fix to cater to an incompetent LLM.

Alternatively, you could take the `determination is None` for such cases as the signal that the output could not be verified and decide what to do with it.